### PR TITLE
BACKLOG-16541 - Reset counter for Jahia version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     </parent>
     <artifactId>ckeditor</artifactId>
     <name>Jahia CKEditor</name>
-    <version>4.17.1-jahia8-3-SNAPSHOT</version>
+    <version>4.17.1-jahia8-1-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>CKEditor module for the Digital Experience Manager platform that provides feature-rich WYSIWYG editor for content authoring.</description>
     <scm>


### PR DESCRIPTION
Reset counter to jahia8-1 as it's the first version for the new ckeditor version (4.17.1)