### PR TITLE
BACKLOG-21969 - Replace action variables by local values

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -37,21 +37,21 @@ jobs:
         shell: bash
         run: |
           git fetch --all
-          git pull origin ${{ inputs.primary_release_branch }} --quiet
+          git pull origin master --quiet
   
       - name: Delete github tag ${{ inputs.release_version }}
         shell: bash
         run: |
-          git config user.email ${{ inputs.git_user_email }}
-          git config user.name ${{ inputs.git_user_name }}
-          git tag --delete ${{ inputs.release_version }}
-          git push origin :refs/tags/${{ inputs.release_version }}
+          git config user.email "jahia-ci@jahia.com"
+          git config user.name "Jahia CI"
+          git tag --delete ${{ github.event.release.tag_name }}
+          git push origin :refs/tags/${{ github.event.release.tag_name }}
   
       - name: Remove any previous changes, this is required by mvn release prepare
         shell: bash
         run: |
           git reset --hard
-          git checkout ${{ inputs.primary_release_branch }}
+          git checkout master
   
       - name: Added some debug details
         shell: bash


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21969

## Description

Bad copy paste from the release Github Action

Even with this change we'll probably still get this error:
```
fatal: detected dubious ownership in repository at '/__w/ckeditor/ckeditor'
To add an exception for this directory, call:

	git config --global --add safe.directory /__w/ckeditor/ckeditor
```